### PR TITLE
Use sudo for make install step of integrated build

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following steps are required to build and install the plugin as part of Wire
     cd build
     cmake ..
     make
-    make install
+    sudo make install
     ```
 
 


### PR DESCRIPTION
When building the "integrated Wireshark with plugin" in Ubuntu [last step in Point "4)" of "As part of Wireshark"], use the command 'sudo make install' instead of 'make install', as this step needs to be run as a sudoer since it is not just about a user compiling their own files for themselves.